### PR TITLE
Add support for Dancer2's new Hash::MultiValue parameters methods

### DIFF
--- a/lib/Dancer2/Plugin/UnicodeNormalize.pm
+++ b/lib/Dancer2/Plugin/UnicodeNormalize.pm
@@ -18,12 +18,13 @@ on_plugin_import {
         Dancer2::Core::Hook->new(
             name => 'before',
             code => sub {
+                my $app = shift;
                 # perhaps better ways to check for Plugin2 but this works
                 if ( $dsl->can('execute_plugin_hook')) {
                     # Plugin2  - fetch fresh config on each run
                     $settings = plugin_setting;
                 }
-                for (@{$settings->{'exclude'}}) { return if $dsl->app->request->path =~ /$_/ }
+                for (@{$settings->{'exclude'}}) { return if $app->request->path =~ /$_/ }
 
                 my $form = $settings->{'form'} || 'NFC';
                 my $normalizer = Unicode::Normalize->can($form);
@@ -34,11 +35,11 @@ on_plugin_import {
                 }
 
                 for (qw/query body route/) {
-                    my $p = $dsl->app->request->params($_);
+                    my $p = $app->request->params($_);
                     next unless $p;
                     %{$p} = map { $_ => $normalizer->($p->{$_}) } grep { $p->{$_} } keys %{$p};
                 }
-                $dsl->app->request->_build_params;
+                $app->request->_build_params;
             },
         ),
     );

--- a/lib/Dancer2/Plugin/UnicodeNormalize.pm
+++ b/lib/Dancer2/Plugin/UnicodeNormalize.pm
@@ -40,6 +40,15 @@ on_plugin_import {
                     %{$p} = map { $_ => $normalizer->($p->{$_}) } grep { $p->{$_} } keys %{$p};
                 }
                 $app->request->_build_params;
+
+                if ( $app->request->can("body_parameters") ) {
+                    for (qw/query_parameters body_parameters route_parameters/) {
+                        my $p = $app->request->$_;
+                        for my $key ( $p->keys ) {
+                            $p->set( $key, map { $_ ? $normalizer->($_) : $_} $p->get_all($key) );
+                        }
+                    }
+                }
             },
         ),
     );

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -4,7 +4,7 @@ use warnings;
 use utf8;
 use charnames ':full';
 
-use Test::More tests => 3;
+use Test::More tests => 6;
 use t::lib::TestApp;
 
 use Plack::Test;
@@ -18,9 +18,18 @@ test_psgi( t::lib::TestApp::dance, sub {
     my ($app) = @_;
 
     my $response = $app->( GET "/cmp/$string1/$string2" );
-    is $response->content => 'eq', 'GET: Equality for differently composed strings';
+    is $response->content => 'eq', 'GET: Equality for differently composed strings using param';
+
+    $response = $app->( GET "/cmp_route/$string1/$string2" );
+    is $response->content => 'eq', 'GET: Equality for differently composed strings using route_parameters';
+
+    $response = $app->( GET "/cmp_query?string1=$string1&string2=$string2" );
+    is $response->content => 'eq', 'GET: Equality for differently composed strings using query_parameters';
 
     $response = $app->( POST '/cmp', [ string1 => $string1, string2 => $string2 ]);
-    is $response->content => 'eq', 'POST: Equality for differently composed strings';
+    is $response->content => 'eq', 'POST: Equality for differently composed strings using param';
+
+    $response = $app->( POST '/cmp_body', [ string1 => $string1, string2 => $string2 ]);
+    is $response->content => 'eq', 'POST: Equality for differently composed strings using body_parameters';
 } );
 

--- a/t/lib/TestApp.pm
+++ b/t/lib/TestApp.pm
@@ -2,6 +2,8 @@ package t::lib::TestApp;
 
 use Dancer2;
 use Dancer2::Plugin::UnicodeNormalize;
+use Unicode::Char;
+my $u = Unicode::Char->new();
 
 set charset => 'UTF-8';
 set apphandler => 'PSGI';
@@ -12,9 +14,24 @@ get '/cmp/:string1/:string2' => sub {
     return ( ( param('string1') eq param('string2') ) ? 'eq' : 'ne' );
 };
 
+get '/cmp_route/:string1/:string2' => sub {
+    return 'missing parameter!' unless ( route_parameters->get('string1') && route_parameters->get('string2') );
+    return ( ( route_parameters->get('string1') eq route_parameters->get('string2') ) ? 'eq' : 'ne' );
+};
+
+get '/cmp_query' => sub {
+    return 'missing parameter!' unless ( query_parameters->get('string1') && query_parameters->get('string2') );
+    return ( ( query_parameters->get('string1') eq query_parameters->get('string2') ) ? 'eq' : 'ne' );
+};
+
 post '/cmp' => sub {
     return 'missing parameter!' unless ( param('string1') && param('string2') );
     return ( ( param('string1') eq param('string2') ) ? 'eq' : 'ne' );
+};
+
+post '/cmp_body' => sub {
+    return 'missing parameter!' unless ( body_parameters->get('string1') && body_parameters->get('string2') );
+    return ( ( body_parameters->get('string1') eq body_parameters->get('string2') ) ? 'eq' : 'ne' );
 };
 
 post '/upload' => sub {


### PR DESCRIPTION
This needs https://github.com/PerlDancer/Dancer2/pull/1219 to be merged into Dancer2 before it can actually work since right now the HMV methods do not decode input data. Hopefully the D2 fix will be part of the next release.
